### PR TITLE
Transform GitHub Page to Back to the Future theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,104 +3,108 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Willkommen bei Audioreworkvisions</title>
+    <title>Zurück in die Zukunft - Audioreworkvisions</title>
+    <link rel="stylesheet" href="style.css">
     <style>
+        /* Time circuit display for header background */
+        header {
+            background: #000033;
+            background-image: linear-gradient(to right, 
+                rgba(0, 0, 51, 0.9), 
+                rgba(0, 0, 102, 0.8)
+            );
+            padding: 3rem;
+            position: relative;
+            overflow: hidden;
+            border-bottom: 3px solid #3fc6ff;
+        }
+        
+        /* Circuit patterns in the background */
+        header::before {
+            content: "";
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-image: 
+                linear-gradient(rgba(63, 198, 255, 0.1) 1px, transparent 1px),
+                linear-gradient(90deg, rgba(63, 198, 255, 0.1) 1px, transparent 1px);
+            background-size: 20px 20px;
+            z-index: 1;
+            pointer-events: none;
+        }
+        
+        /* Flux capacitor glow effect */
+        h1, h2 {
+            color: #ff2800;
+            text-shadow: 0 0 10px rgba(255, 40, 0, 0.7);
+            font-family: "Arial", sans-serif;
+            font-weight: bold;
+            letter-spacing: 2px;
+            position: relative;
+            z-index: 2;
+        }
+        
+        /* DeLorean speedometer style list */
+        ul {
+            list-style-type: none;
+            padding: 0;
+        }
+        
+        ul li {
+            margin: 10px 0;
+            padding: 10px;
+            background-color: rgba(0, 0, 0, 0.5);
+            border: 1px solid #3fc6ff;
+            border-radius: 5px;
+            transition: all 0.3s ease;
+        }
+        
+        ul li:hover {
+            background-color: rgba(63, 198, 255, 0.2);
+            transform: translateX(10px);
+            box-shadow: 0 0 15px rgba(63, 198, 255, 0.5);
+        }
+        
+        /* Time travel link style */
+        a {
+            color: #3fc6ff;
+            text-decoration: none;
+            transition: all 0.3s ease;
+            position: relative;
+        }
+        
+        a:hover {
+            color: #ffff00;
+            text-shadow: 0 0 5px #ffff00;
+        }
+        
         body {
-            background-color: #121212; /* Dunkler Hintergrund */
-            color: #e0e0e0; /* Helle Schriftfarbe */
-            font-family: Helvetica, sans-serif;
+            background-color: #000000;
+            color: #ffffff;
+            font-family: "Arial", sans-serif;
             margin: 0;
             padding: 0;
             display: flex;
             flex-direction: column;
             min-height: 100vh;
-        }
-
-        header {
-            background: url('brandkit-bsm.png') no-repeat center center fixed; /* Muster des Goldenen Schnitts */
-            background-size: cover;
-            padding: 3rem;
-        }
-
-        nav.breadcrumb {
-            font-size: 0.875rem;
-            margin-bottom: 1.25rem;
-        }
-
-        nav.breadcrumb a {
-            color: #40e0d0; /* Minzgrün */
-            text-decoration: none;
-        }
-
-        nav.breadcrumb a:hover {
-            text-decoration: underline;
-        }
-
-        footer {
-            background-color: #1c1c1c;
-            color: #e0e0e0;
-            text-align: center;
-            padding: 1.25rem;
-        }
-
-        h1 {
-            font-size: 2.25rem;
-            font-weight: bold;
-        }
-
-        h2 {
-            font-size: 2.25rem;
-            font-weight: bold;
-        }
-
-        h3 {
-            font-size: 1.625rem;
-        }
-
-        p {
-            font-size: 1.625rem;
-        }
-
-        a {
-            color: #40e0d0; /* Minzgrün */
-        }
-
-        a:hover {
-            color: #e0e0e0; /* Helle Schriftfarbe */
-        }
-
-        main {
-            flex: 1;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-        }
-
-        .container {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-        }
-
-        .section {
-            margin-bottom: 2rem;
-            text-align: center;
+            background-image: linear-gradient(to bottom, #000033, #000000);
         }
     </style>
 </head>
 <body>
     <header>
         <nav class="breadcrumb">
-            <a href="index.html">Home</a> &gt; <a href="index.html">Willkommen bei Audioreworkvisions</a>
+            <a href="index.html">OCT 26 1985</a> &gt; <a href="index.html">DESTINATION TIME</a>
         </nav>
-        <h1>Willkommen bei Audioreworkvisions</h1>
+        <h1>ZURÜCK IN DIE ZUKUNFT - AUDIOREWORKVISIONS</h1>
     </header>
     <main>
         <div class="container">
             <section class="section">
-                <h2>Über Audioreworkvisions</h2>
-                <p>Willkommen auf der offiziellen Webseite von Audioreworkvisions. Hier finden Sie eine Sammlung von Blogbeiträgen, Dokumentationen und Artikeln zu verschiedenen Themen rund um Audioreworkvisions.</p>
+                <h2>ABOUT AUDIOREWORKVISIONS</h2>
+                <p>Willkommen in der Zeitmaschine von Audioreworkvisions. Hier finden Sie eine Sammlung von Blogbeiträgen, Dokumentationen und Artikeln zu verschiedenen Themen - 1.21 GIGAWATT POWER!</p>
             </section>
             <section class="section">
                 <h2>Inhaltsverzeichnis</h2>
@@ -133,7 +137,29 @@
         </div>
     </main>
     <footer>
-        <p>&copy; 2025 AUDIOREWORKVISIONS. Alle Rechte vorbehalten.</p>
+        <p>&copy; 1985-2025 AUDIOREWORKVISIONS. "Your future is whatever you make it, so make it a good one!"</p>
     </footer>
+    <div class="time-travel-effect" id="timeTravelEffect"></div>
+    <script>
+        // Time travel effect when clicking links
+        document.addEventListener('DOMContentLoaded', function() {
+            const links = document.querySelectorAll('a');
+            const timeTravelEffect = document.getElementById('timeTravelEffect');
+            
+            links.forEach(link => {
+                link.addEventListener('click', function(e) {
+                    if (this.href !== window.location.href) {
+                        e.preventDefault();
+                        timeTravelEffect.style.opacity = '0';
+                        timeTravelEffect.style.animation = 'timeTravel 1s';
+                        
+                        setTimeout(() => {
+                            window.location.href = this.href;
+                        }, 1000);
+                    }
+                });
+            });
+        });
+    </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,17 +1,18 @@
 /* Main styles for api2store */
 
 :root {
-  --primary-color: #007bff;
-  --secondary-color: #6c757d;
-  --background-color: #ffffff;
-  --text-color: #333333;
-  --border-color: #eaeaea;
-  --hover-color: #0056b3;
-  --dark-blue: #3B3B3B;
-  --mint-green: #40e0d0;
-  --magenta: #ff00ff;
-  --light-text: #222222;
-  --dark-text: #333333;
+  --primary-color: #ff2800; /* Red like the BTTF logo */
+  --secondary-color: #3fc6ff; /* Electric blue for time circuits */
+  --background-color: #000000; /* Black background */
+  --text-color: #ffffff; /* White text */
+  --border-color: #3fc6ff; /* Electric blue borders */
+  --hover-color: #ff9900; /* Orange hover like the BTTF flames */
+  --dark-blue: #000033; /* Dark blue for depth */
+  --title-color: #ff2800; /* Red title color */
+  --flux-yellow: #ffff00; /* Flux capacitor yellow */
+  --digital-green: #00ff66; /* Time circuit display green */
+  --light-text: #ffffff; /* Light text color */
+  --dark-text: #000000; /* Dark text */
 }
 
 /* Header and Navigation styles */
@@ -351,4 +352,155 @@ header p {
   100% {
     transform: scale(1);
   }
+}
+
+/* Back to the Future Theme */
+body {
+  font-family: "digital-clock", "Courier New", monospace;
+  line-height: 1.6;
+  color: var(--text-color);
+  background-color: var(--background-color);
+  background-image: linear-gradient(to bottom, #000033, #000000);
+  position: relative;
+  overflow-x: hidden;
+}
+
+/* Digital clock font for the time travel look */
+@font-face {
+  font-family: 'digital-clock';
+  src: url('https://fonts.cdnfonts.com/css/alarm-clock') format('woff');
+  font-weight: normal;
+  font-style: normal;
+}
+
+/* Header with DeLorean-inspired styling */
+header {
+  background: linear-gradient(to right, #000033, #000044);
+  border-bottom: 3px solid var(--secondary-color);
+  padding: 2rem;
+  position: relative;
+  overflow: hidden;
+}
+
+header::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: repeating-linear-gradient(
+    45deg,
+    rgba(63, 198, 255, 0.05),
+    rgba(63, 198, 255, 0.05) 10px,
+    rgba(63, 198, 255, 0) 10px,
+    rgba(63, 198, 255, 0) 20px
+  );
+  z-index: 1;
+  pointer-events: none;
+}
+
+header h1 {
+  color: var(--primary-color);
+  text-shadow: 0 0 10px rgba(255, 40, 0, 0.7);
+  font-size: 2.5rem;
+  letter-spacing: 2px;
+  animation: flicker 2s infinite alternate;
+}
+
+/* Time circuit display effect for navigation */
+nav.breadcrumb {
+  background-color: rgba(0, 0, 0, 0.7);
+  padding: 0.5rem;
+  border-radius: 5px;
+  border: 1px solid var(--secondary-color);
+  display: inline-block;
+}
+
+nav.breadcrumb a {
+  color: var(--digital-green);
+  text-decoration: none;
+  font-family: "digital-clock", "Courier New", monospace;
+  letter-spacing: 1px;
+  position: relative;
+}
+
+nav.breadcrumb a:hover {
+  color: var(--flux-yellow);
+  text-shadow: 0 0 5px var(--flux-yellow);
+}
+
+/* Flux capacitor pulsing animation */
+@keyframes flicker {
+  0%, 18%, 22%, 25%, 53%, 57%, 100% {
+    opacity: 1;
+  }
+  20%, 24%, 55% {
+    opacity: 0.7;
+  }
+}
+
+/* Time travel effect animations */
+.time-travel-effect {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 9999;
+  opacity: 0;
+  background: linear-gradient(to right, #ff2800, #3fc6ff);
+  transition: opacity 0.5s;
+}
+
+@keyframes timeTravel {
+  0% {
+    opacity: 0;
+  }
+  10% {
+    opacity: 0.8;
+  }
+  20% {
+    opacity: 0;
+  }
+  30% {
+    opacity: 0.6;
+  }
+  40% {
+    opacity: 0;
+  }
+  50% {
+    opacity: 0.7;
+  }
+  60% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+/* Digital LED count display */
+.count-display {
+  font-family: "digital-clock", "Courier New", monospace;
+  color: var(--digital-green);
+  background-color: #000;
+  padding: 5px 10px;
+  border-radius: 3px;
+  border: 1px solid var(--secondary-color);
+  display: inline-block;
+  margin-right: 10px;
+}
+
+/* Time circuit display styling */
+.time-circuit {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-around;
+  margin: 2rem 0;
+  background-color: #111;
+  border: 2px solid var(--primary-color);
+  border-radius: 10px;
+  padding: 1rem;
 }


### PR DESCRIPTION
This PR transforms the GitHub Page to have a Back to the Future theme, including:

- New color scheme matching the Back to the Future colors (red, electric blue)
- Digital clock font styling for time travel aesthetic
- Circuit board patterns in the header background
- Time travel animations when clicking links
- Updated text with Back to the Future references
- DeLorean-inspired UI elements

Link to Devin run: https://app.devin.ai/sessions/2fab454adcc64ed583fe429ec07bb9d4

Requested by: Poeschmann Marco